### PR TITLE
Update LIBSSLURL to libssl1.1_1.1.1f-1ubuntu2.23_xxx.deb

### DIFF
--- a/src/ubuntu/install/squid/install/install_squid.sh
+++ b/src/ubuntu/install/squid/install/install_squid.sh
@@ -3,10 +3,10 @@ set -ex
 
 ARCH=$(arch | sed 's/aarch64/arm64/g' | sed 's/x86_64/amd64/g')
 if [[ "${ARCH}" == "arm64" ]]; then
-  LIBSSLURL="http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_arm64.deb"
+  LIBSSLURL="http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_arm64.deb"
   RPMLIBSSL="https://ap.edge.kernel.org/fedora/releases/39/Everything/aarch64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.aarch64.rpm"
 else
-  LIBSSLURL="http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb"
+  LIBSSLURL="http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"
   RPMLIBSSL="https://ap.edge.kernel.org/fedora/releases/39/Everything/x86_64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.x86_64.rpm"
 fi
 


### PR DESCRIPTION
### Summary

I fixed the issue where download errors for `libssl1.1` started occurring on some distributions.

### Cause

Due to the security update, the deb package was replaced with a new one.

### A previous similar commit that might be helpful

https://github.com/kasmtech/workspaces-core-images/commit/e9320b6ec4412e8fa3245091a24628dd21551c11

### Detail

OK:

```console
% docker image build -t my-core-ubuntu-focal --build-arg BASE_IMAGE=ubuntu:focal-20240530 -f dockerfile-kasm-core .
```

NG:

```console
% docker image build -t my-core-ubuntu-jammy --build-arg BASE_IMAGE=ubuntu:jammy-20240627.1 -f dockerfile-kasm-core .
…
 > [base_layer 50/77] RUN bash /dockerstartup/install/squid_install/install_squid.sh && rm -rf /dockerstartup/install/squid_install/:
0.089 ++ arch
0.089 ++ sed s/aarch64/arm64/g
0.089 ++ sed s/x86_64/amd64/g
0.090 + ARCH=arm64
0.090 + [[ arm64 == \a\r\m\6\4 ]]
0.090 + LIBSSLURL=http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_arm64.deb
0.090 + RPMLIBSSL=https://ap.edge.kernel.org/fedora/releases/39/Everything/aarch64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.aarch64.rpm
0.090 + SQUID_COMMIT=1149fc830c7edcb383eec390cce2beba16befde5
0.090 ++ grep -q Jammy /etc/os-release
0.090 + wget -qO- https://kasmweb-build-artifacts.s3.amazonaws.com/kasm-squid-builder/1149fc830c7edcb383eec390cce2beba16befde5/output/kasm-squid-builder_arm64.tar.gz
0.091 + tar -xzf - -C /
5.373 + wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_arm64.deb -O libssl1.1.arm64.deb
5.374 --2024-08-03 10:11:45--  http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_arm64.deb
5.374 Resolving ports.ubuntu.com (ports.ubuntu.com)... 185.125.190.39, 185.125.190.36, 2620:2d:4000:1::19, ...
5.727 Connecting to ports.ubuntu.com (ports.ubuntu.com)|185.125.190.39|:80... connected.
5.967 HTTP request sent, awaiting response... 404 Not Found
…
```

It seems that there is no deb package to download. Check it.

```console
% curl -I http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_arm64.deb
HTTP/1.1 404 Not Found
Date: Sat, 03 Aug 2024 11:35:57 GMT

% curl -I http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_arm64.deb
HTTP/1.1 200 OK
Date: Sat, 03 Aug 2024 11:36:04 GMT
Last-Modified: Wed, 31 Jul 2024 15:47:03 GMT
Accept-Ranges: bytes
Content-Length: 1158808
```

### Details of the `openssl` update

https://launchpad.net/ubuntu/+source/openssl/1.1.1f-1ubuntu2.23

### NOTE

[RPMLIBSSL(openssl1.1-1.1.1q-5.fc39.xxx.rpm)](https://github.com/kasmtech/workspaces-core-images/blob/cbf2076f787aeeb7a0d7a7c0987c507b4d34dfbf/src/ubuntu/install/squid/install/install_squid.sh#L5-L11) has NOT been updated YET.

```console
% curl -I https://ap.edge.kernel.org/fedora/releases/39/Everything/aarch64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.aarch64.rpm
HTTP/1.1 200 OK
```
