### PR TITLE
Add check for ~/Desktop

### DIFF
--- a/src/common/startup_scripts/kasm_default_profile.sh
+++ b/src/common/startup_scripts/kasm_default_profile.sh
@@ -13,6 +13,8 @@ function copy_default_profile_to_home {
 function verify_profile_config {
     echo "Verifying Uploads/Downloads Configurations"
 
+    [ -d "$HOME/Desktop" ] || mkdir -p "$HOME/Desktop"
+
     mkdir -p $HOME/Uploads
 
     if [ -d "$HOME/Desktop/Uploads" ]; then


### PR DESCRIPTION
If ~/Desktop is not present, kasm_default_profile.sh fails. Creates ~/Desktop if not already a directory.